### PR TITLE
Add experimental MCP sampling provider

### DIFF
--- a/.changeset/experimental-server-sampling.md
+++ b/.changeset/experimental-server-sampling.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": minor
+---
+
+Add experimental MCP server sampling support. A new `mcp` provider delegates requests to VS Code's sampling API. Enable with the `experimentalServerSampling` flag in configuration.

--- a/assets/AGENTS.md
+++ b/assets/AGENTS.md
@@ -102,6 +102,8 @@ Task Master provides an MCP server that Claude Code can connect to. Configure in
 }
 ```
 
+Enable VS Code server sampling by setting `"experimentalServerSampling": true` in `.taskmaster/config.json` and toggling VS Code's `"chat.mcp.serverSampling"` setting.
+
 ### Essential MCP Tools
 
 ```javascript

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,7 +42,8 @@ Taskmaster uses two primary methods for configuration:
           "ollamaBaseURL": "http://localhost:11434/api",
           "azureBaseURL": "https://your-endpoint.azure.com/",
           "vertexProjectId": "your-gcp-project-id",
-          "vertexLocation": "us-central1"
+          "vertexLocation": "us-central1",
+          "experimentalServerSampling": false
         }
       }
       ```

--- a/scripts/modules/ai-services-unified.js
+++ b/scripts/modules/ai-services-unified.js
@@ -24,7 +24,8 @@ import {
 	getAzureBaseURL,
 	getBedrockBaseURL,
 	getVertexProjectId,
-	getVertexLocation
+	getVertexLocation,
+	getServerSamplingFlag
 } from './config-manager.js';
 import { log, findProjectRoot, resolveEnvVariable } from './utils.js';
 
@@ -39,7 +40,8 @@ import {
 	OllamaAIProvider,
 	BedrockAIProvider,
 	AzureProvider,
-	VertexAIProvider
+	VertexAIProvider,
+	MCPProvider
 } from '../../src/ai-providers/index.js';
 
 // Create provider instances
@@ -53,7 +55,8 @@ const PROVIDERS = {
 	ollama: new OllamaAIProvider(),
 	bedrock: new BedrockAIProvider(),
 	azure: new AzureProvider(),
-	vertex: new VertexAIProvider()
+	vertex: new VertexAIProvider(),
+	mcp: new MCPProvider()
 };
 
 // Helper function to get cost for a specific model
@@ -306,6 +309,7 @@ async function _unifiedServiceRunner(serviceType, params) {
 
 	const effectiveProjectRoot = projectRoot || findProjectRoot();
 	const userId = getUserId(effectiveProjectRoot);
+	const serverSamplingEnabled = getServerSamplingFlag(effectiveProjectRoot);
 
 	let sequence;
 	if (initialRole === 'main') {
@@ -371,8 +375,14 @@ async function _unifiedServiceRunner(serviceType, params) {
 				continue;
 			}
 
+			const useSampling =
+				serverSamplingEnabled || providerName?.toLowerCase() === 'mcp';
+			const loggedProviderName = useSampling ? 'mcp' : providerName;
+
 			// Get provider instance
-			provider = PROVIDERS[providerName?.toLowerCase()];
+			provider = useSampling
+				? PROVIDERS['mcp']
+				: PROVIDERS[providerName?.toLowerCase()];
 			if (!provider) {
 				log(
 					'warn',
@@ -385,7 +395,7 @@ async function _unifiedServiceRunner(serviceType, params) {
 			}
 
 			// Check API key if needed
-			if (providerName?.toLowerCase() !== 'ollama') {
+			if (!useSampling && providerName?.toLowerCase() !== 'ollama') {
 				if (!isApiKeySet(providerName, session, effectiveProjectRoot)) {
 					log(
 						'warn',
@@ -419,11 +429,13 @@ async function _unifiedServiceRunner(serviceType, params) {
 
 			// Get AI parameters for the current role
 			roleParams = getParametersForRole(currentRole, effectiveProjectRoot);
-			apiKey = _resolveApiKey(
-				providerName?.toLowerCase(),
-				session,
-				effectiveProjectRoot
-			);
+			if (!useSampling) {
+				apiKey = _resolveApiKey(
+					providerName?.toLowerCase(),
+					session,
+					effectiveProjectRoot
+				);
+			}
 
 			// Prepare provider-specific configuration
 			let providerSpecificParams = {};
@@ -498,14 +510,14 @@ async function _unifiedServiceRunner(serviceType, params) {
 			}
 
 			const callParams = {
-				apiKey,
 				modelId,
 				maxTokens: roleParams.maxTokens,
 				temperature: roleParams.temperature,
 				messages,
-				...(baseURL && { baseURL }),
+				...(baseURL && !useSampling && { baseURL }),
 				...(serviceType === 'generateObject' && { schema, objectName }),
 				...providerSpecificParams,
+				...(useSampling ? { session, systemPrompt } : { apiKey }),
 				...restApiParams
 			};
 
@@ -513,7 +525,7 @@ async function _unifiedServiceRunner(serviceType, params) {
 				provider,
 				serviceType,
 				callParams,
-				providerName,
+				loggedProviderName,
 				modelId,
 				currentRole
 			);
@@ -523,7 +535,7 @@ async function _unifiedServiceRunner(serviceType, params) {
 					telemetryData = await logAiUsage({
 						userId,
 						commandName,
-						providerName,
+						providerName: loggedProviderName,
 						modelId,
 						inputTokens: providerResponse.usage.inputTokens,
 						outputTokens: providerResponse.usage.outputTokens,
@@ -536,7 +548,7 @@ async function _unifiedServiceRunner(serviceType, params) {
 			} else if (userId && providerResponse && !providerResponse.usage) {
 				log(
 					'warn',
-					`Cannot log telemetry for ${commandName} (${providerName}/${modelId}): AI result missing 'usage' data. (May be expected for streams)`
+					`Cannot log telemetry for ${commandName} (${loggedProviderName}/${modelId}): AI result missing 'usage' data. (May be expected for streams)`
 				);
 			}
 

--- a/scripts/modules/config-manager.js
+++ b/scripts/modules/config-manager.js
@@ -62,7 +62,8 @@ const DEFAULTS = {
 		defaultPriority: 'medium',
 		projectName: 'Task Master',
 		ollamaBaseURL: 'http://localhost:11434/api',
-		bedrockBaseURL: 'https://bedrock.us-east-1.amazonaws.com'
+		bedrockBaseURL: 'https://bedrock.us-east-1.amazonaws.com',
+		experimentalServerSampling: false
 	}
 };
 
@@ -388,6 +389,10 @@ function getBedrockBaseURL(explicitRoot = null) {
 	return getGlobalConfig(explicitRoot).bedrockBaseURL;
 }
 
+function getServerSamplingFlag(explicitRoot = null) {
+	return getGlobalConfig(explicitRoot).experimentalServerSampling === true;
+}
+
 /**
  * Gets the Google Cloud project ID for Vertex AI from configuration
  * @param {string|null} explicitRoot - Optional explicit path to the project root.
@@ -480,7 +485,10 @@ function getParametersForRole(role, explicitRoot = null) {
  */
 function isApiKeySet(providerName, session = null, projectRoot = null) {
 	// Define the expected environment variable name for each provider
-	if (providerName?.toLowerCase() === 'ollama') {
+	if (
+		providerName?.toLowerCase() === 'ollama' ||
+		providerName?.toLowerCase() === 'mcp'
+	) {
 		return true; // Indicate key status is effectively "OK"
 	}
 
@@ -786,6 +794,7 @@ export {
 	getOllamaBaseURL,
 	getAzureBaseURL,
 	getBedrockBaseURL,
+	getServerSamplingFlag,
 	getParametersForRole,
 	getUserId,
 	// API Key Checkers (still relevant)

--- a/scripts/modules/supported-models.json
+++ b/scripts/modules/supported-models.json
@@ -423,5 +423,12 @@
 			"allowed_roles": ["main", "fallback"],
 			"max_tokens": 32768
 		}
+	],
+	"mcp": [
+		{
+			"id": "server-sampling",
+			"cost_per_1m_tokens": { "input": 0, "output": 0 },
+			"allowed_roles": ["main", "fallback", "research"]
+		}
 	]
 }

--- a/src/ai-providers/index.js
+++ b/src/ai-providers/index.js
@@ -13,3 +13,4 @@ export { OllamaAIProvider } from './ollama.js';
 export { BedrockAIProvider } from './bedrock.js';
 export { AzureProvider } from './azure.js';
 export { VertexAIProvider } from './google-vertex.js';
+export { MCPProvider } from './mcp.js';

--- a/src/ai-providers/mcp.js
+++ b/src/ai-providers/mcp.js
@@ -1,0 +1,52 @@
+import { BaseAIProvider } from './base-provider.js';
+
+export class MCPProvider extends BaseAIProvider {
+	constructor() {
+		super();
+		this.name = 'MCP';
+	}
+
+	validateAuth(_params) {
+		// No API key needed
+	}
+
+	async #callSampling(params) {
+		const { session, messages, systemPrompt, maxTokens, temperature } = params;
+		if (!session || typeof session.requestSampling !== 'function') {
+			throw new Error('MCP session with requestSampling required');
+		}
+		this.validateMessages(messages);
+		try {
+			const response = await session.requestSampling({
+				messages,
+				systemPrompt,
+				maxTokens,
+				temperature
+			});
+			return response;
+		} catch (error) {
+			this.handleError('server sampling', error);
+		}
+	}
+
+	async generateText(params) {
+		const res = await this.#callSampling(params);
+		return { text: res?.content?.text || '', usage: null };
+	}
+
+	async streamText(params) {
+		const result = await this.#callSampling(params);
+		return result?.content?.text || '';
+	}
+
+	async generateObject(params) {
+		const res = await this.#callSampling(params);
+		let obj;
+		try {
+			obj = JSON.parse(res?.content?.text || '{}');
+		} catch (_) {
+			throw new Error('Failed to parse object from sampling response');
+		}
+		return { object: obj, usage: null };
+	}
+}

--- a/tests/unit/ai-services-unified.test.js
+++ b/tests/unit/ai-services-unified.test.js
@@ -11,6 +11,7 @@ const mockGetParametersForRole = jest.fn();
 const mockGetUserId = jest.fn();
 const mockGetDebugFlag = jest.fn();
 const mockIsApiKeySet = jest.fn();
+const mockGetServerSamplingFlag = jest.fn();
 
 // --- Mock MODEL_MAP Data ---
 // Provide a simplified structure sufficient for cost calculation tests
@@ -108,6 +109,7 @@ jest.unstable_mockModule('../../scripts/modules/config-manager.js', () => ({
 	getDefaultSubtasks: mockGetDefaultSubtasks,
 	getDefaultPriority: mockGetDefaultPriority,
 	getProjectName: mockGetProjectName,
+	getServerSamplingFlag: mockGetServerSamplingFlag,
 
 	// API Key and provider functions
 	isApiKeySet: mockIsApiKeySet,
@@ -145,6 +147,12 @@ const mockOllamaProvider = {
 	generateObject: jest.fn()
 };
 
+const mockMCPProvider = {
+	generateText: jest.fn(),
+	streamText: jest.fn(),
+	generateObject: jest.fn()
+};
+
 // Mock the provider classes to return our mock instances
 jest.unstable_mockModule('../../src/ai-providers/index.js', () => ({
 	AnthropicAIProvider: jest.fn(() => mockAnthropicProvider),
@@ -166,6 +174,7 @@ jest.unstable_mockModule('../../src/ai-providers/index.js', () => ({
 		generateObject: jest.fn()
 	})),
 	OllamaAIProvider: jest.fn(() => mockOllamaProvider),
+	MCPProvider: jest.fn(() => mockMCPProvider),
 	BedrockAIProvider: jest.fn(() => ({
 		generateText: jest.fn(),
 		streamText: jest.fn(),
@@ -686,6 +695,21 @@ describe('Unified AI Services', () => {
 
 			// Should have gotten the anthropic response
 			expect(result.mainResult).toBe('Anthropic response with session key');
+		});
+
+		test('should use MCP provider when server sampling enabled', async () => {
+			mockGetServerSamplingFlag.mockReturnValue(true);
+			mockMCPProvider.generateText.mockResolvedValue({ text: 'sampled' });
+
+			const session = { requestSampling: jest.fn() };
+			const params = { role: 'main', prompt: 'sample', session };
+
+			const result = await generateTextService(params);
+
+			expect(mockMCPProvider.generateText).toHaveBeenCalledTimes(1);
+			const callArgs = mockMCPProvider.generateText.mock.calls[0][0];
+			expect(callArgs.session).toBe(session);
+			expect(result.mainResult).toBe('sampled');
 		});
 	});
 });

--- a/tests/unit/config-manager.test.js
+++ b/tests/unit/config-manager.test.js
@@ -140,7 +140,8 @@ const DEFAULT_CONFIG = {
 		defaultPriority: 'medium',
 		projectName: 'Task Master',
 		ollamaBaseURL: 'http://localhost:11434/api',
-		bedrockBaseURL: 'https://bedrock.us-east-1.amazonaws.com'
+		bedrockBaseURL: 'https://bedrock.us-east-1.amazonaws.com',
+		experimentalServerSampling: false
 	}
 };
 


### PR DESCRIPTION
## Summary
- implement `MCPProvider` that sends requests via `session.requestSampling`
- register new provider and enable it when `experimentalServerSampling` flag is true
- bypass API key checks for `mcp` provider
- document server sampling flag
- update tests and configuration defaults

## Testing
- `npm run format-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_684c6d5e9b908332b0aa6687a5647094